### PR TITLE
chore: remove routes to gateway in google run. 

### DIFF
--- a/.github/workflows/pushMasterDeploy.yml
+++ b/.github/workflows/pushMasterDeploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:

--- a/firebase.json
+++ b/firebase.json
@@ -3,34 +3,6 @@
     "public": "public",
     "rewrites": [
       {
-        "source": "/",
-        "run": {
-          "serviceId": "gateway",
-          "region": "us-central1"
-        }
-      },
-      {
-        "source": "/graphql",
-        "run": {
-          "serviceId": "gateway",
-          "region": "us-central1"
-        }
-      },
-      {
-        "source": "/view",
-        "run": {
-          "serviceId": "gateway",
-          "region": "us-central1"
-        }
-      },
-      {
-        "source": "/.internal/**",
-        "run": {
-          "serviceId": "gateway",
-          "region": "us-central1"
-        }
-      },
-      {
         "source": "/profile",
         "function": "fileUploadGateway"
       },


### PR DESCRIPTION
remove routes to gateway in google run.  api is no longer routed through Firebase and doesn't require these website routes. The routes which remain for for functions
Set explicit version on `actions/checkout`